### PR TITLE
Remove duplicate 'steps'

### DIFF
--- a/.github/workflows/monthly-report-for-oncall.yml
+++ b/.github/workflows/monthly-report-for-oncall.yml
@@ -16,7 +16,6 @@ jobs:
     container:
       image: ubuntu:bionic
     steps:
-    steps:
     - uses: actions/checkout@v1
     - uses: ros-security/github-contribution-report-generator@0.0.6
       with:


### PR DESCRIPTION
Monthly report workflow was failing due to a duplicate 'steps'