### PR TITLE
Include ros-tooling/aws-oncall in repo activity workflow

### DIFF
--- a/.github/workflows/repo-activity.yaml
+++ b/.github/workflows/repo-activity.yaml
@@ -32,6 +32,7 @@ jobs:
         - osrf/osrf_testing_tools_cpp
         - ros-perception/laser_geometry
         - ros-planning/navigation_msgs
+        - ros-tooling/aws-oncall
         - ros-tooling/libstatistics_collector
         - ros-visualization/interactive_markers
         - ros-visualization/python_qt_binding


### PR DESCRIPTION
This will send the metrics for this repository (open issues, etc) to CloudWatch

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>