### PR TITLE
Fix pypi stats reporting schedule

### DIFF
--- a/.github/workflows/pypi-stats.yml
+++ b/.github/workflows/pypi-stats.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-    schedule:
-      - cron: '0 9  * * *' # run every day at 9am (chosen randomly)
+  schedule:
+    - cron: '0 9  * * *' # run every day at 9am (chosen randomly)
 
 jobs:
   pypi_stats:


### PR DESCRIPTION
The schedule specifier was nested inside the `push` trigger, so it wasn't being interpreted and run daily